### PR TITLE
feat(docker): Voice Agent 서비스 추가

### DIFF
--- a/agent.env.example
+++ b/agent.env.example
@@ -1,0 +1,12 @@
+# AWS Credentials (for Transcribe, Polly, Bedrock)
+AWS_ACCESS_KEY_ID=your-access-key-id
+AWS_SECRET_ACCESS_KEY=your-secret-access-key
+AWS_DEFAULT_REGION=ap-northeast-2
+
+# LiveKit connection
+LIVEKIT_URL=wss://your-domain.com
+LIVEKIT_API_KEY=your-livekit-api-key
+LIVEKIT_API_SECRET=your-livekit-api-secret
+
+# Optional
+LOG_LEVEL=INFO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,15 @@ services:
       - '127.0.0.1:3000:3000'
     restart: unless-stopped
 
+  agent:
+    build:
+      context: ../ops-api/agents
+    env_file:
+      - ./agent.env
+    depends_on:
+      - livekit
+    restart: unless-stopped
+
 volumes:
   caddy_data:
   caddy_config:


### PR DESCRIPTION
## 개요
Voice Agent를 Docker Compose에 서비스로 추가합니다.

## 변경 사항
- `docker-compose.yml`에 agent 서비스 정의
- `agent.env.example` 환경변수 템플릿 추가

## 의존성
- ops-api#21 완료 후 머지 권장

closes #7