### PR TITLE
[Fix] LiveKit 에이전트 연결 실패 해결 (LIVEKIT_URL 수정)

### DIFF
--- a/agent.env.example
+++ b/agent.env.example
@@ -4,7 +4,10 @@ AWS_SECRET_ACCESS_KEY=your-secret-access-key
 AWS_DEFAULT_REGION=ap-northeast-2
 
 # LiveKit connection
+# Local development (agent runs with network_mode: host):
 LIVEKIT_URL=ws://localhost:7880
+# Production (if agent runs on a different host from LiveKit):
+# LIVEKIT_URL=ws://livekit-server-hostname:7880
 LIVEKIT_API_KEY=your-livekit-api-key
 LIVEKIT_API_SECRET=your-livekit-api-secret
 

--- a/agent.env.example
+++ b/agent.env.example
@@ -4,7 +4,7 @@ AWS_SECRET_ACCESS_KEY=your-secret-access-key
 AWS_DEFAULT_REGION=ap-northeast-2
 
 # LiveKit connection
-LIVEKIT_URL=wss://your-domain.com
+LIVEKIT_URL=ws://localhost:7880
 LIVEKIT_API_KEY=your-livekit-api-key
 LIVEKIT_API_SECRET=your-livekit-api-secret
 


### PR DESCRIPTION
## 📋 변경 사항

- `agent.env.example`의 LIVEKIT_URL을 `ws://localhost:7880`으로 수정
- 설정 가이드 주석 추가 (network_mode: host 사용 시 localhost 연결 필요)

## 🔗 관련 이슈

Related to Namanmoo-Damso/ops-api#44

## 📝 상세 설명

에이전트가 `network_mode: host`로 실행될 때, 외부 도메인이 아닌 localhost로 LiveKit에 직접 연결해야 합니다. 기존 예시 URL(`wss://your-domain.com`)은 포트가 명시되지 않아 기본 포트 80으로 연결을 시도하지만, LiveKit은 7880 포트에서 실행되므로 연결이 실패했습니다.

## ✅ 체크리스트
- [x] 브랜치/커밋 규칙 준수
- [x] 변경 사항 설명 기재