### PR TITLE
feat: Universal Links 및 env.example 정리

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,8 +2,37 @@
   email greyhairchooselife@gmail.com
 }
 
+(aasa) {
+  header Content-Type "application/json"
+  respond `{
+    "applinks": {
+      "apps": [],
+      "details": [
+        {
+          "appIDs": ["4Y5BW58548.com.ilim.damso"],
+          "components": [
+            {
+              "/": "/invite*",
+              "comment": "어르신 초대 링크"
+            }
+          ]
+        }
+      ]
+    }
+  }` 200
+}
+
 1.sodam.store {
-  # LiveKit 관련 경로를 먼저 처리
+  log {
+    output stdout
+    format json
+  }
+  handle /.well-known/apple-app-site-association {
+    import aasa
+  }
+  handle /apple-app-site-association {
+    import aasa
+  }
   handle /rtc* {
     reverse_proxy 127.0.0.1:7880
   }
@@ -29,6 +58,16 @@
 
 2.sodam.store {
   # LiveKit 관련 경로를 먼저 처리
+  log {
+    output stdout
+    format json
+  }
+  handle /.well-known/apple-app-site-association {
+    import aasa
+  }
+  handle /apple-app-site-association {
+    import aasa
+  }
   handle /rtc* {
     reverse_proxy 127.0.0.1:7880
   }
@@ -54,6 +93,16 @@
 
 3.sodam.store {
   # LiveKit 관련 경로를 먼저 처리
+  log {
+    output stdout
+    format json
+  }
+  handle /.well-known/apple-app-site-association {
+    import aasa
+  }
+  handle /apple-app-site-association {
+    import aasa
+  }
   handle /rtc* {
     reverse_proxy 127.0.0.1:7880
   }
@@ -79,6 +128,16 @@
 
 4.sodam.store {
   # LiveKit 관련 경로를 먼저 처리
+  log {
+    output stdout
+    format json
+  }
+  handle /.well-known/apple-app-site-association {
+    import aasa
+  }
+  handle /apple-app-site-association {
+    import aasa
+  }
   handle /rtc* {
     reverse_proxy 127.0.0.1:7880
   }
@@ -104,6 +163,16 @@
 
 5.sodam.store {
   # LiveKit 관련 경로를 먼저 처리
+  log {
+    output stdout
+    format json
+  }
+  handle /.well-known/apple-app-site-association {
+    import aasa
+  }
+  handle /apple-app-site-association {
+    import aasa
+  }
   handle /rtc* {
     reverse_proxy 127.0.0.1:7880
   }

--- a/agent.env.example
+++ b/agent.env.example
@@ -11,9 +11,6 @@ LIVEKIT_URL=ws://localhost:7880
 LIVEKIT_API_KEY=your-livekit-api-key
 LIVEKIT_API_SECRET=your-livekit-api-secret
 
-# Redis for caching transcripts
-REDIS_URL=redis://localhost:6379/0
-
 # API endpoint (what agent should call for ops-api)
 API_BASE_URL=http://localhost:8080
 

--- a/api.env.example
+++ b/api.env.example
@@ -1,9 +1,6 @@
 # Database
 DATABASE_URL=postgresql://damso:pw@db:5432/damso
 
-# Redis
-REDIS_URL=redis://redis:6379
-
 # LiveKit
 LIVEKIT_URL=wss://your-domain.com
 LIVEKIT_API_KEY=your-api-key
@@ -24,25 +21,23 @@ APNS_KEY_ID=your-key-id
 APNS_TEAM_ID=your-team-id
 APNS_BUNDLE_ID=your-bundle-id
 APNS_ENV=prod
+APNS_KEY_PATH=/path/to/AuthKey.p8
+APNS_VOIP_TOPIC=com.your.app.voip
 
-# naver map 또한 필요함
-NEXT_PUBLIC_NAVER_MAP_CLIENT_ID=
 # https://developers.kakao.com/console/app에서 발급
 KAKAO_CLIENT_ID=<KAKAO_API_KEY>
 KAKAO_CLIENT_SECRET=<KAKAO_CLIENT_SECRET>
+KAKAO_ADMIN_KEY=<KAKAO_ADMIN_KEY>
+
 # https://console.cloud.google.com/에서 발급
 GOOGLE_CLIENT_ID=<GOOGLE_CLIENT_ID>
 GOOGLE_CLIENT_SECRET=<GOOGLE_보안_비밀번호>
 
-# ai service
-AI_PROVIDER=bedrock                                   # "bedrock" 또는 "openai"
-OPENAI_API_KEY=<your_key>
-OPENAI_MODEL=gpt-4-turbo                              # 선택 사항 (기본값: gpt-4o-mini)
-AWS_REGION=us-east-1                                  # 이게 속편함
+# AI Service
+AI_PROVIDER=bedrock
+AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=<your_key>
 AWS_SECRET_ACCESS_KEY=<your_secret>
-BEDROCK_MODEL=global.anthropic.claude-sonnet-4-5-20250929-v1:0 # 선택 사항 (기본값: haiku)
-# 토큰 수 설정 (기본값: 1000)
+BEDROCK_MODEL=global.anthropic.claude-sonnet-4-5-20250929-v1:0
 AI_MAX_TOKENS=2000
-# 시스템 프롬프트 설정 (선택 사항)
 AI_INSTRUCTION='당신은 따뜻한 마음을 가진 노인 심리 상담가입니다. 대화의 이면을 깊이 있게 분석해주세요.'


### PR DESCRIPTION
## Summary
- iOS Universal Links (AASA) 설정 추가
- env.example 파일들 실제 사용과 동기화

## Changes
### Caddyfile
- `(aasa)` snippet 추가 (Apple App Site Association)
- 1~5.sodam.store 모든 도메인에 AASA 핸들러 추가

### api.env.example
- 미사용 변수 제거: `REDIS_URL`, `OPENAI_*`, `NEXT_PUBLIC_NAVER_MAP_CLIENT_ID`
- 누락 변수 추가: `APNS_KEY_PATH`, `APNS_VOIP_TOPIC`, `KAKAO_ADMIN_KEY`

### agent.env.example
- 미사용 변수 제거: `REDIS_URL`
- 유지: `API_BASE_URL` (origin/dev에서 추가됨)

## Test Plan
- [ ] 각 도메인에서 `/.well-known/apple-app-site-association` 응답 확인
- [ ] iOS 앱에서 Universal Links 동작 확인

Closes #16