### PR TITLE
chore: Caddyfile에서 AASA 코드 제거

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,197 +1,143 @@
 {
-  email greyhairchooselife@gmail.com
-}
-
-(aasa) {
-  header Content-Type "application/json"
-  respond `{
-    "applinks": {
-      "apps": [],
-      "details": [
-        {
-          "appIDs": ["4Y5BW58548.com.ilim.damso"],
-          "components": [
-            {
-              "/": "/invite*",
-              "comment": "어르신 초대 링크"
-            }
-          ]
-        }
-      ]
-    }
-  }` 200
+	email greyhairchooselife@gmail.com
 }
 
 1.sodam.store {
-  log {
-    output stdout
-    format json
-  }
-  handle /.well-known/apple-app-site-association {
-    import aasa
-  }
-  handle /apple-app-site-association {
-    import aasa
-  }
-  handle /rtc* {
-    reverse_proxy 127.0.0.1:7880
-  }
-  handle /twirp* {
-    reverse_proxy 127.0.0.1:7880
-  }
-  handle /webhook/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /v1/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /admin/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /healthz {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle {
-    reverse_proxy 127.0.0.1:3000
-  }
+	log {
+		output stdout
+		format json
+	}
+	handle /rtc* {
+		reverse_proxy 127.0.0.1:7880
+	}
+	handle /twirp* {
+		reverse_proxy 127.0.0.1:7880
+	}
+	handle /webhook/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /v1/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /admin/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /healthz {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle {
+		reverse_proxy 127.0.0.1:3000
+	}
 }
 
 2.sodam.store {
-  # LiveKit 관련 경로를 먼저 처리
-  log {
-    output stdout
-    format json
-  }
-  handle /.well-known/apple-app-site-association {
-    import aasa
-  }
-  handle /apple-app-site-association {
-    import aasa
-  }
-  handle /rtc* {
-    reverse_proxy 127.0.0.1:7880
-  }
-  handle /twirp* {
-    reverse_proxy 127.0.0.1:7880
-  }
-  handle /webhook/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /v1/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /admin/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /healthz {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle {
-    reverse_proxy 127.0.0.1:3000
-  }
+	log {
+		output stdout
+		format json
+	}
+	handle /rtc* {
+		reverse_proxy 127.0.0.1:7880
+	}
+	handle /twirp* {
+		reverse_proxy 127.0.0.1:7880
+	}
+	handle /webhook/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /v1/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /admin/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /healthz {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle {
+		reverse_proxy 127.0.0.1:3000
+	}
 }
 
 3.sodam.store {
-  # LiveKit 관련 경로를 먼저 처리
-  log {
-    output stdout
-    format json
-  }
-  handle /.well-known/apple-app-site-association {
-    import aasa
-  }
-  handle /apple-app-site-association {
-    import aasa
-  }
-  handle /rtc* {
-    reverse_proxy 127.0.0.1:7880
-  }
-  handle /twirp* {
-    reverse_proxy 127.0.0.1:7880
-  }
-  handle /webhook/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /v1/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /admin/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /healthz {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle {
-    reverse_proxy 127.0.0.1:3000
-  }
+	log {
+		output stdout
+		format json
+	}
+	handle /rtc* {
+		reverse_proxy 127.0.0.1:7880
+	}
+	handle /twirp* {
+		reverse_proxy 127.0.0.1:7880
+	}
+	handle /webhook/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /v1/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /admin/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /healthz {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle {
+		reverse_proxy 127.0.0.1:3000
+	}
 }
 
 4.sodam.store {
-  # LiveKit 관련 경로를 먼저 처리
-  log {
-    output stdout
-    format json
-  }
-  handle /.well-known/apple-app-site-association {
-    import aasa
-  }
-  handle /apple-app-site-association {
-    import aasa
-  }
-  handle /rtc* {
-    reverse_proxy 127.0.0.1:7880
-  }
-  handle /twirp* {
-    reverse_proxy 127.0.0.1:7880
-  }
-  handle /webhook/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /v1/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /admin/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /healthz {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle {
-    reverse_proxy 127.0.0.1:3000
-  }
+	log {
+		output stdout
+		format json
+	}
+	handle /rtc* {
+		reverse_proxy 127.0.0.1:7880
+	}
+	handle /twirp* {
+		reverse_proxy 127.0.0.1:7880
+	}
+	handle /webhook/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /v1/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /admin/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /healthz {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle {
+		reverse_proxy 127.0.0.1:3000
+	}
 }
 
 5.sodam.store {
-  # LiveKit 관련 경로를 먼저 처리
-  log {
-    output stdout
-    format json
-  }
-  handle /.well-known/apple-app-site-association {
-    import aasa
-  }
-  handle /apple-app-site-association {
-    import aasa
-  }
-  handle /rtc* {
-    reverse_proxy 127.0.0.1:7880
-  }
-  handle /twirp* {
-    reverse_proxy 127.0.0.1:7880
-  }
-  handle /webhook/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /v1/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /admin/* {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle /healthz {
-    reverse_proxy 127.0.0.1:8080
-  }
-  handle {
-    reverse_proxy 127.0.0.1:3000
-  }
+	log {
+		output stdout
+		format json
+	}
+	handle /rtc* {
+		reverse_proxy 127.0.0.1:7880
+	}
+	handle /twirp* {
+		reverse_proxy 127.0.0.1:7880
+	}
+	handle /webhook/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /v1/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /admin/* {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle /healthz {
+		reverse_proxy 127.0.0.1:8080
+	}
+	handle {
+		reverse_proxy 127.0.0.1:3000
+	}
 }


### PR DESCRIPTION
## 변경 사항
- `(aasa)` 스니펫 삭제
- 각 도메인(1-5.sodam.store)의 apple-app-site-association 핸들러 삭제

## 이유
- AASA 기능 더 이상 사용하지 않음

Closes #18